### PR TITLE
Add up and down arrow support - #30

### DIFF
--- a/src/components/Todo/common/Todo/Form/index.tsx
+++ b/src/components/Todo/common/Todo/Form/index.tsx
@@ -1,14 +1,14 @@
-import React, { useState } from "react";
-import uuid from "react-uuid";
-import AddIcon from "@material-ui/icons/Add";
+import React, { useState } from 'react';
+import uuid from 'react-uuid';
+import AddIcon from '@material-ui/icons/Add';
 import {
   Container,
   FormControl,
   TextField,
   makeStyles,
-} from "@material-ui/core";
+} from '@material-ui/core';
 
-import { TodoItem } from "../../types";
+import { TodoItem } from '../../types';
 
 export interface AddProps {
   addItem: (item: TodoItem | TodoItem[]) => void;
@@ -16,18 +16,18 @@ export interface AddProps {
 
 const useStyles = makeStyles({
   root: {
-    display: "flex",
-    width: "100%",
+    display: 'flex',
+    width: '100%',
   },
   plusIcon: {
-    margin: "5px 10px 0px 8px",
+    margin: '5px 10px 0px 8px',
   },
 });
 
 export const Form = (props: AddProps) => {
   const classes = useStyles();
   const { addItem } = props;
-  const [itemName, setItemName] = useState("");
+  const [itemName, setItemName] = useState('');
 
   return (
     <Container className={classes.root}>
@@ -42,10 +42,10 @@ export const Form = (props: AddProps) => {
             // Get pasted data via clipboard API
             const clipboardData = e.clipboardData;
             const pastedData = clipboardData
-              .getData("Text")
-              .split("\n")
+              .getData('Text')
+              .split('\n')
               .reverse()
-              .filter((name) => name.trim() !== "");
+              .filter((name) => name.trim() !== '');
 
             // Do whatever with pasteddata
             const items = pastedData.map((name) => {
@@ -59,12 +59,30 @@ export const Form = (props: AddProps) => {
               uuid: uuid(),
               isComplete: false,
             });
-            setItemName("");
+            setItemName('');
           }}
-          placeholder="Add item."
+          placeholder='Add item.'
           value={itemName}
-          className="w-10/12"
+          className='w-10/12'
           autoFocus
+          onKeyDown={(e) => {
+            if (e.key === 'ArrowDown') {
+              // Move cursor down to the next item
+              let focusedElement = document.activeElement as HTMLInputElement;
+              const inputs = document.querySelectorAll("input[type='text']");
+              const inputsArray = Array.from(inputs);
+
+              let index = inputsArray.indexOf(focusedElement);
+              // Checks if the focusedElement is at the bottom
+              if (index < inputsArray.length - 1) {
+                let nextInputElement = inputsArray[
+                  index + 1
+                ] as HTMLInputElement;
+
+                nextInputElement.focus();
+              }
+            }
+          }}
         />
       </FormControl>
     </Container>

--- a/src/components/Todo/common/Todo/Form/index.tsx
+++ b/src/components/Todo/common/Todo/Form/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import uuid from 'react-uuid';
 import AddIcon from '@material-ui/icons/Add';
 import {
@@ -28,12 +28,14 @@ export const Form = (props: AddProps) => {
   const classes = useStyles();
   const { addItem } = props;
   const [itemName, setItemName] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
 
   return (
     <Container className={classes.root}>
       <AddIcon className={classes.plusIcon} />
       <FormControl fullWidth>
         <TextField
+          inputRef={inputRef}
           onPaste={(e) => {
             // Stop data actually being pasted into div
             e.stopPropagation();
@@ -68,14 +70,15 @@ export const Form = (props: AddProps) => {
           onKeyDown={(e) => {
             if (e.key === 'ArrowDown') {
               // Move cursor down to the next item
-              let focusedElement = document.activeElement as HTMLInputElement;
               const inputs = document.querySelectorAll("input[type='text']");
               const inputsArray = Array.from(inputs);
+              const index = inputsArray.indexOf(
+                inputRef.current as HTMLInputElement
+              );
 
-              let index = inputsArray.indexOf(focusedElement);
-              // Checks if the focusedElement is at the bottom
+              // Checks if the focused item is at the bottom
               if (index < inputsArray.length - 1) {
-                let nextInputElement = inputsArray[
+                const nextInputElement = inputsArray[
                   index + 1
                 ] as HTMLInputElement;
 

--- a/src/components/Todo/common/Todo/Item/index.tsx
+++ b/src/components/Todo/common/Todo/Item/index.tsx
@@ -1,50 +1,49 @@
-import React, { FC, useEffect, useRef, useState } from "react";
+import React, { FC, useEffect, useRef, useState } from 'react';
 
-import uuid from "react-uuid";
+import uuid from 'react-uuid';
 import {
   Checkbox,
   Container,
   FormControl,
   makeStyles,
   TextField,
-} from "@material-ui/core";
-import { Reorder, useMotionValue } from "framer-motion";
-import CloseIcon from "@material-ui/icons/Close";
-import DragIndicatorIcon from "@material-ui/icons/DragIndicator";
-import useRaisedShadow from "./useRaisedShadow";
-import { TodoItem } from "../../types";
+} from '@material-ui/core';
+import { Reorder, useMotionValue } from 'framer-motion';
+import CloseIcon from '@material-ui/icons/Close';
+import DragIndicatorIcon from '@material-ui/icons/DragIndicator';
+import useRaisedShadow from './useRaisedShadow';
+import { TodoItem } from '../../types';
 
 const useStyles = makeStyles({
   root: {
-    display: "flex",
-    width: "100%",
-    alignItems: "center",
+    display: 'flex',
+    width: '100%',
+    alignItems: 'center',
     zIndex: 0,
   },
   underline: {
-    "&&&:before": {
-      borderBottom: "none",
+    '&&&:before': {
+      borderBottom: 'none',
     },
   },
   textFeild: {
-    padding: "10px 0px 7px",
+    padding: '10px 0px 7px',
   },
   dragIndicatorIcon: {
-    cursor: "grab",
+    cursor: 'grab',
   },
   closeIcon: {
-    cursor: "pointer",
-     padding:"2px",
+    cursor: 'pointer',
+    padding: '2px',
     '&:hover': {
-      backgroundColor: "#b9b5b5",
-      borderRadius: '50%', 
-    }
-
+      backgroundColor: '#b9b5b5',
+      borderRadius: '50%',
+    },
   },
   reorderItem: {
-    listStyle: "none",
-    position: "relative",
-    backgroundColor: "white",
+    listStyle: 'none',
+    position: 'relative',
+    backgroundColor: 'white',
   },
 });
 
@@ -60,13 +59,14 @@ export const Item: FC<Props> = ({
   itemIndex,
   setItemsCallback,
   addItem,
+  // handleArrowUpDown,
 }) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const y = useMotionValue(0);
   const boxShadow = useRaisedShadow(y);
   const classes = useStyles();
 
-  const [itemText, setItemText] = useState("");
+  const [itemText, setItemText] = useState('');
   const [draggable, setDraggable] = useState(false);
 
   useEffect(() => {
@@ -112,10 +112,10 @@ export const Item: FC<Props> = ({
                 // Get pasted data via clipboard API
                 const clipboardData = e.clipboardData;
                 const pastedData = clipboardData
-                  .getData("Text")
-                  .split("\n")
+                  .getData('Text')
+                  .split('\n')
                   .reverse()
-                  .filter((name) => name.trim() !== "");
+                  .filter((name) => name.trim() !== '');
 
                 // Do whatever with pasteddata
                 const items = pastedData.map((name) => {
@@ -131,10 +131,38 @@ export const Item: FC<Props> = ({
                 setItemsCallback([...items]);
               }}
               onKeyPress={(e) =>
-                e.key === "Enter" &&
+                e.key === 'Enter' &&
                 itemIndex < 1 &&
-                addItem({ name: "", uuid: uuid(), isComplete: false })
+                addItem({ name: '', uuid: uuid(), isComplete: false })
               }
+              onKeyDown={(e) => {
+                let focusedElement = document.activeElement as HTMLInputElement;
+                const inputs = document.querySelectorAll("input[type='text']");
+                const inputsArray = Array.from(inputs);
+
+                let index = inputsArray.indexOf(focusedElement);
+                if (focusedElement.type === 'text') {
+                  if (e.key === 'ArrowUp') {
+                    // Move cursor to the previous item
+                    // Checks if the focusedElement is at the top
+                    if (index >= 0) {
+                      const nextInputElement = inputsArray[
+                        index - 1
+                      ] as HTMLInputElement;
+                      nextInputElement.focus();
+                    }
+                  } else if (e.key === 'ArrowDown') {
+                    // Move cursor to the next item
+                    // Checks if the focusedElement is at the bottom
+                    if (index < inputsArray.length - 1) {
+                      let nextInputElement = inputsArray[
+                        index + 1
+                      ] as HTMLInputElement;
+                      nextInputElement.focus();
+                    }
+                  }
+                }
+              }}
             />
           </FormControl>
           <CloseIcon

--- a/src/components/Todo/common/Todo/Item/index.tsx
+++ b/src/components/Todo/common/Todo/Item/index.tsx
@@ -136,15 +136,16 @@ export const Item: FC<Props> = ({
                 addItem({ name: '', uuid: uuid(), isComplete: false })
               }
               onKeyDown={(e) => {
-                let focusedElement = document.activeElement as HTMLInputElement;
                 const inputs = document.querySelectorAll("input[type='text']");
                 const inputsArray = Array.from(inputs);
+                const index = inputsArray.indexOf(
+                  inputRef.current as HTMLInputElement
+                );
 
-                let index = inputsArray.indexOf(focusedElement);
-                if (focusedElement.type === 'text') {
+                if (inputRef.current) {
                   if (e.key === 'ArrowUp') {
                     // Move cursor to the previous item
-                    // Checks if the focusedElement is at the top
+                    // Checks if the focused item is at the top
                     if (index >= 0) {
                       const nextInputElement = inputsArray[
                         index - 1
@@ -153,9 +154,9 @@ export const Item: FC<Props> = ({
                     }
                   } else if (e.key === 'ArrowDown') {
                     // Move cursor to the next item
-                    // Checks if the focusedElement is at the bottom
+                    // Checks if the focused item is at the bottom
                     if (index < inputsArray.length - 1) {
-                      let nextInputElement = inputsArray[
+                      const nextInputElement = inputsArray[
                         index + 1
                       ] as HTMLInputElement;
                       nextInputElement.focus();


### PR DESCRIPTION
User is now able to navigate up and down through ToDoItems with the up and down arrow keys

- It will stop the user at the top and bottom of the list and do nothing without throwing any errors
- It will allow the user to up arrow to the top of the list including the 'add item' TextField