### PR TITLE
Issue: Wrap text with limit of 1200 chars #22

### DIFF
--- a/src/components/Todo/common/Todo/Item/index.tsx
+++ b/src/components/Todo/common/Todo/Item/index.tsx
@@ -107,6 +107,7 @@ export const Item: FC<Props> = ({
           />
           <FormControl fullWidth>
             <TextField
+              multiline
               className={classes.textFeild}
               InputProps={{ classes: { underline: classes.underline } }}
               inputRef={inputRef}

--- a/src/components/Todo/common/Todo/Item/index.tsx
+++ b/src/components/Todo/common/Todo/Item/index.tsx
@@ -55,7 +55,9 @@ interface Props {
   changeFocus:  (focusIndex: number) => void;
   focus: number;
 }
-
+function displayErrorMessage(message: string): void {
+  alert(message);
+}
 export const Item: FC<Props> = ({
   items,
   itemIndex,
@@ -116,12 +118,17 @@ export const Item: FC<Props> = ({
 
                 // Get pasted data via clipboard API
                 const clipboardData = e.clipboardData;
-                const pastedData = clipboardData
-                  .getData('Text')
-                  .split('\n')
+                const MAX_CHARACTERS = 1200;
+                const input = clipboardData
+                  .getData("Text");
+                if(input.length > MAX_CHARACTERS) {
+                  displayErrorMessage(`You can only paste up to ${MAX_CHARACTERS} characters.`);
+                  return;
+                }
+                const pastedData = input
+                  .split("\n")
                   .reverse()
                   .filter((name) => name.trim() !== '');
-
                 // Do whatever with pasteddata
                 const items = pastedData.map((name) => {
                   return { name, uuid: uuid(), isComplete: false };


### PR DESCRIPTION
Handle Paste condition:

Description:
When user tries to paste content more than 1200 characters than a alert will be shown with a proper message.
Also todo item will support multiline feature.